### PR TITLE
Add a user so npm does not run as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,6 @@ COPY dist /usr/src/app/dist
 
 EXPOSE 8000
 
+USER node
+
 CMD ["npm", "run", "start:back"]


### PR DESCRIPTION
Use the unprivileged user created in the base-image to run `npm` instead of the user root.